### PR TITLE
Updated footer with telegram links

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -95,7 +95,7 @@
             <div class="row">
                 <div class="col-xs-6">
                     <img src="/img/ubports-small.png" class="ubports" title="UBports" />
-                    <a href="https://ubports.com/telegram">Join us on Telegram!</a>
+                    We're on Telegram! <a href="https://ubports.com/telegram">UBports</a> / <a href="https://telegram.me/joinchat/BMTh8AHtOL2foXLulmqDxw">OpenStore</a>
                 </div>
                 <div class="col-xs-6 right-align">
                     <a href="https://github.com/UbuntuOpenStore">Source</a> /


### PR DESCRIPTION
On the UBports group on Telegram, we have got some feedback about the discoverability of the link for our group on Telegram. People actually expect to find the OpenStore link in the footer